### PR TITLE
turn `modify_message` into map before passing around

### DIFF
--- a/lib/absinthe_proto/application.ex
+++ b/lib/absinthe_proto/application.ex
@@ -1,10 +1,21 @@
 defmodule AbsintheProto.Application do
   use Application
+  require Logger
 
   def start(_, _) do
     children = []
 
+    validate_modify_message!()
+
     opts = [strategy: :one_for_one, name: AbsintheProto.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp validate_modify_message! do
+    AbsintheProto.DSL.load_modify_message()
+  rescue
+    err ->
+      Logger.error("\n\nInvalid configuration (syntax error) for `config :absinthe_proto, :modify_message`\n\n")
+      reraise(err, __STACKTRACE__)
   end
 end

--- a/lib/absinthe_proto/application.ex
+++ b/lib/absinthe_proto/application.ex
@@ -1,27 +1,10 @@
 defmodule AbsintheProto.Application do
   use Application
-  require Logger
 
   def start(_, _) do
     children = []
 
-    validate_modify_message!()
-
     opts = [strategy: :one_for_one, name: AbsintheProto.Supervisor]
     Supervisor.start_link(children, opts)
-  end
-
-  defp validate_modify_message! do
-    case Application.get_env(:absinthe_proto, :modify_message) do
-      str when is_binary(str) ->
-        Code.eval_string(str)
-        true
-      _ ->
-        true
-    end
-  rescue 
-    err ->
-      Logger.error("\n\nInvalid configuration (syntax error) for `config :absinthe_proto, :modify_message`\n\n")
-      reraise(err, __STACKTRACE__)
   end
 end

--- a/lib/absinthe_proto/dsl.ex
+++ b/lib/absinthe_proto/dsl.ex
@@ -248,13 +248,8 @@ defmodule AbsintheProto.DSL do
       for mod <- mods,
                 !!Map.get(build_struct.modify_message, mod) do
         case Map.get(build_struct.modify_message, mod) do
-          {m, f} when is_atom(m) and is_atom(f) ->
-            apply(m, f, [mod])
           fun when is_function(fun) ->
             fun.(mod)
-          str when is_binary(str) ->
-            {map, _} = Code.eval_string(str)
-            map
           _ -> raise "unknown modifier! expected a 1 arity function"
         end
       end

--- a/lib/absinthe_proto/dsl.ex
+++ b/lib/absinthe_proto/dsl.ex
@@ -193,12 +193,7 @@ defmodule AbsintheProto.DSL do
     {opts, _} = Module.eval_quoted(__CALLER__, options)
     ns = Keyword.get(opts, :namespace)
 
-    modify_message =
-      :absinthe_proto
-      |> Application.get_env(:modify_message, %{})
-      |> maybe_hydrate_modify_message()
-
-    build_struct = %__MODULE__{options: opts, namespace: ns, modify_message: modify_message}
+    build_struct = %__MODULE__{options: opts, namespace: ns, modify_message: load_modify_message()}
 
     save_draft_build(build_struct, __CALLER__.module)
 
@@ -230,11 +225,18 @@ defmodule AbsintheProto.DSL do
     nil
   end
 
-  defp maybe_hydrate_modify_message(mod_msg) when is_binary(mod_msg) do
+  @doc false
+  def load_modify_message do
+    :absinthe_proto
+    |> Application.get_env(:modify_message, %{})
+    |> maybe_transform_modify_message!()
+  end
+
+  defp maybe_transform_modify_message!(mod_msg) when is_binary(mod_msg) do
     {mod, _} = Code.eval_string(mod_msg)
     mod
   end
-  defp maybe_hydrate_modify_message(mod_msg), do: mod_msg
+  defp maybe_transform_modify_message!(mod_msg) when is_map(mod_msg), do: mod_msg
 
   defp apply_configured_modifiers(mod) do
     build_struct = current_draft_build!(mod)

--- a/lib/absinthe_proto/dsl.ex
+++ b/lib/absinthe_proto/dsl.ex
@@ -193,7 +193,10 @@ defmodule AbsintheProto.DSL do
     {opts, _} = Module.eval_quoted(__CALLER__, options)
     ns = Keyword.get(opts, :namespace)
 
-    modify_message = Application.get_env(:absinthe_proto, :modify_message, %{})
+    modify_message =
+      :absinthe_proto
+      |> Application.get_env(:modify_message, %{})
+      |> maybe_hydrate_modify_message()
 
     build_struct = %__MODULE__{options: opts, namespace: ns, modify_message: modify_message}
 
@@ -227,6 +230,12 @@ defmodule AbsintheProto.DSL do
     nil
   end
 
+  defp maybe_hydrate_modify_message(mod_msg) when is_binary(mod_msg) do
+    {mod, _} = Code.eval_string(mod_msg)
+    mod
+  end
+  defp maybe_hydrate_modify_message(mod_msg), do: mod_msg
+
   defp apply_configured_modifiers(mod) do
     build_struct = current_draft_build!(mod)
 
@@ -252,7 +261,6 @@ defmodule AbsintheProto.DSL do
 
     Enum.reject(results, &is_nil/1)
   end
-
 
   @doc """
   Used within a build call. Provide a list of proto objects to ignore


### PR DESCRIPTION
There are a couple places where we expect the `modify_message` to be a map. 